### PR TITLE
Add back missing proxy headers

### DIFF
--- a/salt/tls-terminator/init.sls
+++ b/salt/tls-terminator/init.sls
@@ -75,6 +75,23 @@ def run():
                 if upstream_hostname == 'site':
                     upstream_hostname = site
 
+            extra_location_config = backend_config.get('extra_location_config', [])
+            if isinstance(extra_location_config, dict):
+                extra_location_config = [extra_location_config]
+
+            # Add X-Request-Id header both ways if the nginx version supports it
+            nginx_version_raw = __salt__['pillar.get']('nginx:version', '0.0.0')
+            nginx_version = tuple(int(num) for num in nginx_version_raw.split('.'))
+            if nginx_version and nginx_version >= (1, 11, 0):
+                extra_location_config.append({
+                    # Add to the response from the proxy
+                    'add_header': 'X-Request-Id $request_id always',
+                })
+                extra_location_config.append({
+                    # Add to the request before it reaches the proxy
+                    'proxy_set_header': 'X-Request-Id $request_id',
+                })
+
             parsed_backends[url] = {
                 'hostname': parsed_backend.hostname,
                 'upstream_hostname': upstream_hostname,
@@ -82,6 +99,7 @@ def run():
                 'port': port,
                 'upstream_identifier': upstream_identifier,
                 'upstream_trust_root': upstream_trust_root,
+                'extra_location_config': extra_location_config,
             }
 
         site_504_page = [
@@ -135,19 +153,6 @@ def run():
         extra_server_config = values.get('extra_server_config', [])
         if isinstance(extra_server_config, dict):
             extra_server_config = [extra_server_config]
-
-        # Add X-Request-Id header both ways if the nginx version supports it
-        nginx_version_raw = __salt__['pillar.get']('nginx:version', '0.0.0')
-        nginx_version = tuple(int(num) for num in nginx_version_raw.split('.'))
-        if nginx_version and nginx_version >= (1, 11, 0):
-            extra_server_config.append({
-                # Add to the response from the proxy
-                'add_header': 'X-Request-Id $request_id always',
-            })
-            extra_server_config.append({
-                # Add to the request before it reaches the proxy
-                'proxy_set_header': 'X-Request-Id $request_id',
-            })
 
         ret['tls-terminator-%s-nginx-site' % site] = {
             'file.managed': [

--- a/salt/tls-terminator/nginx/site
+++ b/salt/tls-terminator/nginx/site
@@ -32,16 +32,19 @@ server {
   {% endfor -%}
   {% endfor %}
 
-  include proxy_params;
-  include cache_params;
-
   {% for url, backend in backends.items() -%}
   location {{ url }} {
     proxy_pass {{ backend.protocol }}://{{ backend.upstream_identifier }};
 
-    # Override the HTTP Host header to the name of the upstream host.
-    # (eg. *.herokuapp.com, prevents having to configure Heroku with the
-    # correct hostname)
+    {% for extra_location_dict in backend.extra_location_config -%}
+    {% for key, value in extra_location_dict.items() -%}
+    {{ key }} {{ value }};
+    {% endfor -%}
+    {% endfor %}
+
+    include proxy_params;
+    include cache_params;
+
     proxy_set_header Host "{{ backend.upstream_hostname }}";
 
     proxy_ssl_trusted_certificate '{{ backend.upstream_trust_root }}';


### PR DESCRIPTION
This puts all proxy_set_header directives back on the same level, which
is needed for the parent level to not be overwritten, which happened
when the include directives were moved from the location block to the
server block (which again was done to prevent shadowing proxy_set_header
directives from the server_extra params).

Currently this means headers can't be customized on a location level,
but since we haven't seen any need for that so far that shouldn't be an
issue.