### PR TITLE
Allow papertrail through outbound firewall

### DIFF
--- a/pillar/test.sls
+++ b/pillar/test.sls
@@ -201,3 +201,7 @@ postgres:
 
 newrelic-sysmond:
     license_key: bogusbogusbogusbogusbogusbogusbogusbogus
+
+# Don't actually apply iptables to prevent locking ourselves out
+iptables:
+    apply: False

--- a/salt/_states/firewall.py
+++ b/salt/_states/firewall.py
@@ -4,7 +4,6 @@ import difflib
 import jinja2
 import json
 import os
-import socket
 import subprocess
 
 RULES_TEMPLATE = jinja2.Template('''
@@ -90,16 +89,6 @@ def append(name, chain='INPUT', table='filter', family='ipv4', **kwargs):
             kwargs['destination'] = ','.join(dns_servers)
         else:
             del kwargs['destination']
-    elif _is_ipv4(destination) and family == 'ipv6' or _is_ipv6(destination) and family == 'ipv4':
-        return {
-            'name': name,
-            'comment': 'Ignored due to wrong family for destination %s' % destination,
-            'result': True,
-            'changes': {},
-        }
-    elif destination and not _is_ipv6(destination) and not _is_ipv4(destination):
-        # not a valid address, assume hostname and allow all destinations
-        del kwargs['destination']
 
     partial_rule = __salt__['iptables.build_rule'](**kwargs)
     full_rule = '-A %s %s' % (chain, partial_rule)
@@ -229,23 +218,3 @@ def _apply_rule_for_family(filename, context, restore_command, apply):
         result = 0
         stderr = ''
     return (result, stderr, changes)
-
-
-def _is_ipv4(address):
-    return _is_ip_family(socket.AF_INET, address)
-
-
-def _is_ipv6(address):
-    return _is_ip_family(socket.AF_INET6, address)
-
-
-def _is_ip_family(family, address):
-    # Asssumes that inet_pton exists, which is fair since this state only works
-    # on systems with iptables anyway
-    if not address:
-        return False
-    try:
-        socket.inet_pton(family, address)
-    except socket.error:  # not a valid address
-        return False
-    return True

--- a/salt/cachish/init.sls
+++ b/salt/cachish/init.sls
@@ -38,4 +38,23 @@ cachish-outgoing-firewall-{{ family }}:
         - jump: ACCEPT
         - require:
             - pkg: cachish
+
+
+{% for protocol in ('tcp', 'udp') %}
+cachish-outgoing-firewall-dns-{{ family }}-{{ protocol }}:
+    firewall.append:
+        - family: {{ family }}
+        - chain: OUTPUT
+        - protocol: {{ protocol }}
+        - dport: 53
+        - destination: system_dns
+        - match:
+            - comment
+            - owner
+        - comment: 'cachish: Allow outgoing DNS'
+        - uid-owner: cachish
+        - jump: ACCEPT
+        - require:
+            - pkg: cachish
+{% endfor %}
 {% endfor %}

--- a/salt/iptables/init.sls
+++ b/salt/iptables/init.sls
@@ -19,6 +19,7 @@ iptables-rules:
     firewall.apply:
         - output_policy: {{ iptables.output_policy }}
         - order: last
+        - apply: {{ iptables.get('apply', True) }}
 
 
 {% for family in ('ipv4', 'ipv6') %}

--- a/salt/newrelic-sysmond/init.sls
+++ b/salt/newrelic-sysmond/init.sls
@@ -52,26 +52,19 @@ newrelic-sysmond-firewall:
             - pkg: newrelic-sysmond
 
 
-{% for family, dns_servers in [
-    ('ipv4', salt['grains.get']('dns:ip4_nameservers')),
-    ('ipv6', salt['grains.get']('dns:ip6_nameservers')),
-    ] %}
+{% for family in ('ipv4', 'ipv6') %}
 {% for protocol in ('udp', 'tcp') %}
 newrelic-sysmond-firewall-outgoing-dns-{{ protocol }}-{{ family }}:
     firewall.append:
         - chain: OUTPUT
         - family: {{ family }}
-        {% if dns_servers %}
-        # Ensures the agent can only talk to the system DNS servers, but fails open if we don't
-        # know the system DNS servers
-        - destination: {{ ','.join(dns_servers) }}
-        {% endif %}
+        - destination: system_dns
         - proto: {{ protocol }}
         - dport: 53
         - match:
             - comment
             - owner
-        - comment: "newrelic: Allow DNS for newrelic agent."
+        - comment: "newrelic: Allow DNS for newrelic agent"
         - uid-owner: newrelic
         - jump: ACCEPT
         - require:

--- a/salt/rsyslog/papertrail/init.sls
+++ b/salt/rsyslog/papertrail/init.sls
@@ -30,20 +30,40 @@ rsyslog-papertrail:
 
 
 # From https://help.papertrailapp.com/kb/configuration/troubleshooting-remote-syslog-reachability/#sending-over-tcp
-{% for ip_range in [
+{% set papertrail_ip_ranges = [
     '67.214.208.0/20',
     '173.247.96.0/19',
     '169.46.82.160/27',
 ] %}
-rsyslog-papertrail-outbound-firewall-{{ ip_range }}:
+rsyslog-papertrail-outbound-firewall:
     firewall.append:
         - family: ipv4
         - chain: OUTPUT
         - protocol: tcp
         - dport: {{ papertrail_destination.rsplit(':')[1] }}
-        - destination: {{ ip_range }}
+        - destination: {{ ','.join(papertrail_ip_ranges) }}
         - match:
             - comment
         - comment: 'rsyslog.papertrail: Allow traffic to papertrail'
         - jump: ACCEPT
-{% endfor %}
+
+
+# TODO: This is currently unnecessary since rsyslog runs as root, but this
+# should be dropped to an unprivileged user
+# {% for family in ('ipv4', 'ipv6') %}
+# {% for protocol in ('udp', 'tcp') %}
+# rsyslog-papertrail-outbound-dns-{{ family }}-{{ protocol }}:
+#     firewall.append:
+#         - family: {{ family }}
+#         - chain: OUTPUT
+#         - protocol: {{ protocol }}
+#         - dport: 53
+#         - destination: system_dns
+#         - match:
+#             - comment
+#             - owner
+#         - comment: 'rsyslog.papertrail: Allow outgoing DNS for papertrail'
+#         - uid-owner: rsyslog
+#         - jump: ACCEPT
+# {% endfor %}
+# {% endfor %}

--- a/salt/rsyslog/papertrail/init.sls
+++ b/salt/rsyslog/papertrail/init.sls
@@ -5,6 +5,8 @@ include:
     - .pillar_check
 
 
+{% set papertrail_destination = salt['pillar.get']('rsyslog:papertrail') %}
+
 rsyslog-papertrail-ca-certs:
     file.managed:
         - name: /etc/papertrail-ca-certs.pem
@@ -22,6 +24,26 @@ rsyslog-papertrail:
         - source: salt://rsyslog/papertrail/papertrail.conf
         - template: jinja
         - context:
-            papertrail_rule: "{{ salt['pillar.get']('rsyslog:papertrail') }}"
+            papertrail_rule: "{{ papertrail_destination }}"
         - watch_in:
             - service: rsyslog
+
+
+# From https://help.papertrailapp.com/kb/configuration/troubleshooting-remote-syslog-reachability/#sending-over-tcp
+{% for ip_range in [
+    '67.214.208.0/20',
+    '173.247.96.0/19',
+    '169.46.82.160/27',
+] %}
+rsyslog-papertrail-outbound-firewall-{{ ip_range }}:
+    firewall.append:
+        - family: ipv4
+        - chain: OUTPUT
+        - protocol: tcp
+        - dport: {{ papertrail_destination.rsplit(':')[1] }}
+        - destination: {{ ip_range }}
+        - match:
+            - comment
+        - comment: 'rsyslog.papertrail: Allow traffic to papertrail'
+        - jump: ACCEPT
+{% endfor %}


### PR DESCRIPTION
Also fixes the `destination` field not actually working if specified as CIDR range or multiple addresses due to a bad sanity check (that failed silently). Also allows cachish to perform DNS requests, and some other firewall related fixes.