### PR TITLE
Turn off cache bypass

### DIFF
--- a/salt/nginx/conf.d/cache_params
+++ b/salt/nginx/conf.d/cache_params
@@ -7,3 +7,4 @@ proxy_cache_bypass {{ nginx.cache_bypass }};
 {% endif -%}
 proxy_cache_use_stale {{ nginx.cache_use_stale }};
 add_header X-Cache-Status $upstream_cache_status;
+proxy_cache_lock on;

--- a/salt/nginx/conf.d/cache_params
+++ b/salt/nginx/conf.d/cache_params
@@ -6,4 +6,4 @@ proxy_cache proxy_upstream_cache;
 proxy_cache_bypass {{ nginx.cache_bypass }};
 {% endif -%}
 proxy_cache_use_stale {{ nginx.cache_use_stale }};
-add_header X-Proxy-Cache $upstream_cache_status;
+add_header X-Cache-Status $upstream_cache_status;

--- a/salt/nginx/conf.d/cache_params
+++ b/salt/nginx/conf.d/cache_params
@@ -6,5 +6,6 @@ proxy_cache proxy_upstream_cache;
 proxy_cache_bypass {{ nginx.cache_bypass }};
 {% endif -%}
 proxy_cache_use_stale {{ nginx.cache_use_stale }};
+proxy_cache_background_update on;
 add_header X-Cache-Status $upstream_cache_status;
 proxy_cache_lock on;

--- a/salt/nginx/conf.d/cache_params
+++ b/salt/nginx/conf.d/cache_params
@@ -1,6 +1,9 @@
+{% from 'nginx/map.jinja' import nginx with context -%}
 # Cache upstream responses, but only according to rules from the
 # upstream.
 proxy_cache proxy_upstream_cache;
-proxy_cache_bypass $http_cache_control;
-proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
+{% if nginx.cache_bypass -%}
+proxy_cache_bypass {{ nginx.cache_bypass }};
+{% endif -%}
+proxy_cache_use_stale {{ nginx.cache_use_stale }};
 add_header X-Proxy-Cache $upstream_cache_status;

--- a/salt/nginx/map.jinja
+++ b/salt/nginx/map.jinja
@@ -21,7 +21,7 @@
         },
         'modules': [],
         'cache_bypass': None,
-        'cache_use_stale': 'error timeout http_500 http_502 http_503 http_504',
+        'cache_use_stale': 'error timeout updating http_500 http_502 http_503 http_504',
     },
     'stretch': {
         'repo': 'deb https://nginx.org/packages/mainline/debian/ stretch nginx',

--- a/salt/nginx/map.jinja
+++ b/salt/nginx/map.jinja
@@ -20,6 +20,8 @@
             'minute': 'random',
         },
         'modules': [],
+        'cache_bypass': None,
+        'cache_use_stale': 'error timeout http_500 http_502 http_503 http_504',
     },
     'stretch': {
         'repo': 'deb https://nginx.org/packages/mainline/debian/ stretch nginx',


### PR DESCRIPTION
Modifies a couple cache parameters:
- Turns off cache bypass
- Enables responding with a stale response while fetching a new one from upstream
- Ensures only a single request is forwarded upstream while the cache is updated
- Renames X-Proxy-Cache to the more standard X-Cache-Status

The bypass and cache parameters is configurable from pillar.