### PR TITLE
Enable setting proxy_pass path

### DIFF
--- a/salt/tls-terminator/init.sls
+++ b/salt/tls-terminator/init.sls
@@ -56,7 +56,7 @@ def run():
 
             # If backend is https it's going out over the network, thus allow it through
             # the firewall
-            target_ip, target_port, remote, family = parse_backend(backend)
+            target_ip, target_port, remote, family, path = parse_backend(backend)
             if remote:
                 if family in ('ipv4', 'both'):
                     outgoing_ipv4_firewall_ports[target_ip].add(port)
@@ -107,6 +107,7 @@ def run():
                 'upstream_hostname': upstream_hostname,
                 'protocol': protocol,
                 'port': port,
+                'path': path,
                 'upstream_identifier': upstream_identifier,
                 'upstream_trust_root': upstream_trust_root,
                 'pam_auth': backend_config.get('pam_auth', values.get('pam_auth')),
@@ -269,7 +270,7 @@ def parse_backend(url):
         normalized_ip = socket.inet_ntop(socket.AF_INET6, packed_ip)
         family = 'ipv6'
 
-    return (normalized_ip, port, remote, family)
+    return (normalized_ip, port, remote, family, parsed_url.path)
 
 
 def get_packed_ip(address):

--- a/salt/tls-terminator/nginx/site
+++ b/salt/tls-terminator/nginx/site
@@ -42,7 +42,7 @@ server {
 
   {% for url, backend in backends.items() -%}
   location {{ url }} {
-    proxy_pass {{ backend.protocol }}://{{ backend.upstream_identifier }};
+    proxy_pass {{ backend.protocol }}://{{ backend.upstream_identifier }}{{ backend.path }};
 
     {% if backend.pam_auth -%}
     # Restrict access to users on this machine with PAM


### PR DESCRIPTION
Without this it's not possible to trim the prefix when forwarding.
Usually a location block like
```
location /prefix {
    proxy_pass https://example.com;
}
```
Causes `GET /prefix` to end up as `GET /prefix` also for the backend.
However, if the proxy_pass statement ends with a path, the prefix is
trimmed from the forwarding request. Thus a block like
```
location /prefix {
    proxy_pass https://example.com/;
}
```
(note the trailing slash) will make a request like `GET /prefix`
translate to `GET /` on the backend. This change preserves the path set
in the upstream in the proxy_pass statement, which enables controlling
this behavior.